### PR TITLE
feat: initialize prisma with migrations and seed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL=postgresql://user:password@localhost:5432/chats
+DIRECT_URL=postgresql://user:password@localhost:5432/chats
+JWT_SECRET=changeme

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@
 $ npm install
 ```
 
+## Database setup
+
+Create a `.env` file based on `.env.example` with your Supabase credentials. Then run:
+
+```bash
+$ npx prisma generate        # optional if the client is not generated
+$ npx prisma migrate deploy  # apply migrations to the database
+$ npm run db:seed            # seed test users
+```
+
 ## Compile and run the project
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "db:seed": "prisma db seed"
   },
   "dependencies": {
     "@apollo/server": "^4.12.2",
@@ -80,5 +81,8 @@
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
+  },
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts"
   }
 }

--- a/prisma/migrations/000_init/migration.sql
+++ b/prisma/migrations/000_init/migration.sql
@@ -1,0 +1,41 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE "User" (
+  "id" UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  "username" TEXT NOT NULL UNIQUE,
+  "password" TEXT NOT NULL
+);
+
+CREATE TABLE "Chat" (
+  "id" UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  "title" TEXT,
+  "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE "_ChatParticipants" (
+  "A" UUID NOT NULL,
+  "B" UUID NOT NULL,
+  CONSTRAINT "_ChatParticipants_A_fkey" FOREIGN KEY ("A") REFERENCES "Chat"("id") ON DELETE CASCADE,
+  CONSTRAINT "_ChatParticipants_B_fkey" FOREIGN KEY ("B") REFERENCES "User"("id") ON DELETE CASCADE,
+  CONSTRAINT "_ChatParticipants_AB_unique" UNIQUE ("A", "B")
+);
+
+CREATE TABLE "Message" (
+  "id" UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  "chatId" UUID NOT NULL,
+  "senderId" UUID NOT NULL,
+  "text" TEXT NOT NULL,
+  "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT "Message_chatId_fkey" FOREIGN KEY ("chatId") REFERENCES "Chat"("id") ON DELETE CASCADE,
+  CONSTRAINT "Message_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User"("id") ON DELETE CASCADE
+);
+
+CREATE TABLE "SeenChat" (
+  "id" UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  "userId" UUID NOT NULL,
+  "chatId" UUID NOT NULL,
+  "seenAt" TIMESTAMPTZ NOT NULL,
+  CONSTRAINT "SeenChat_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE,
+  CONSTRAINT "SeenChat_chatId_fkey" FOREIGN KEY ("chatId") REFERENCES "Chat"("id") ON DELETE CASCADE,
+  CONSTRAINT "SeenChat_user_chat_unique" UNIQUE ("userId", "chatId")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,3 +7,41 @@ datasource db {
   url       = env("DATABASE_URL")
   directUrl = env("DIRECT_URL")
 }
+
+model User {
+  id        String    @id @default(uuid())
+  username  String    @unique
+  password  String
+  chats     Chat[]    @relation("ChatParticipants")
+  messages  Message[]
+  seenChats SeenChat[]
+}
+
+model Chat {
+  id           String      @id @default(uuid())
+  title        String?
+  participants User[]      @relation("ChatParticipants")
+  messages     Message[]
+  createdAt    DateTime    @default(now())
+}
+
+model Message {
+  id        String   @id @default(uuid())
+  chatId    String
+  chat      Chat     @relation(fields: [chatId], references: [id])
+  senderId  String
+  sender    User     @relation(fields: [senderId], references: [id])
+  text      String
+  createdAt DateTime @default(now())
+}
+
+model SeenChat {
+  id     String   @id @default(uuid())
+  userId String
+  chatId String
+  seenAt DateTime
+  user   User    @relation(fields: [userId], references: [id])
+  chat   Chat    @relation(fields: [chatId], references: [id])
+
+  @@unique([userId, chatId])
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,29 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const users = [
+    { username: 'alice', password: 'password1' },
+    { username: 'bob', password: 'password2' },
+  ];
+  for (const u of users) {
+    await prisma.user.upsert({
+      where: { username: u.username },
+      update: {},
+      create: {
+        username: u.username,
+        password: u.password,
+      },
+    });
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { GraphQLModule } from '@nestjs/graphql';
+import { PrismaModule } from './prisma/prisma.module';
 
 @Module({
   imports: [
@@ -11,6 +12,7 @@ import { GraphQLModule } from '@nestjs/graphql';
       graphiql: true,
       autoSchemaFile: true,
     }),
+    PrismaModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/prisma/prisma.module.ts
+++ b/src/prisma/prisma.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,0 +1,17 @@
+import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit {
+  async onModuleInit(): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    await this.$connect();
+  }
+
+  enableShutdownHooks(app: INestApplication): void {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    this.$on('beforeExit', async () => {
+      await app.close();
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- define Prisma schema for users, chats, messages and seen chats
- generate initial migration SQL
- add Prisma module/service for NestJS
- add seed script and npm script `db:seed`
- document DB setup instructions
- provide env example

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68519b0591e88322a11f0373bbba2e10